### PR TITLE
Update CLI to output JSON

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,7 +13,7 @@ if (tooManyArguments)
 
 languageEncoding(path)
   .then((fileInfo) => {
-    console.log(fileInfo);
+    console.log(JSON.stringify(fileInfo, null, 4));
   })
   .catch((error) => {
     console.log(error);


### PR DESCRIPTION
Use JSON.stringify to pretty-print output. This allows processing with further tools, as simply printing the JS object doesn't result in techincally valid JSON.