### PR TITLE
Correct argument type in typescript signature

### DIFF
--- a/src/index-node.d.ts
+++ b/src/index-node.d.ts
@@ -7,5 +7,5 @@ export interface FileInfo {
     },
 }
 
-declare function DetectFileEncodingAndLanguage(file: File): Promise<FileInfo>;
+declare function DetectFileEncodingAndLanguage(path: string | Buffer | URL): Promise<FileInfo>;
 export default DetectFileEncodingAndLanguage;


### PR DESCRIPTION
Changes the typescript signature of the default function to take a `string | Buffer | URL` rather than a `File`. The argument gets passed to `fs.readFile` and `fs.createReadStream` which take a path represented as a `string | Buffer | URL` rather than a `File`.