### PR TITLE
Support Buffer input in Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ export default function App() {
 ```
 
 ### In Node
+#### File
 
 ```js
 // server.js
@@ -73,6 +74,15 @@ const languageEncoding = require("detect-file-encoding-and-language");
 const pathToFile = "/home/username/documents/my-text-file.txt";
 languageEncoding(pathToFile).then((fileInfo) => console.log(fileInfo));
 // Possible result: { language: japanese, encoding: Shift-JIS, confidence: { encoding: 0.94, language: 0.94 } }
+```
+
+#### Buffer
+
+```js
+// server.js
+const languageEncoding = require("detect-file-encoding-and-language");
+const content = Buffer.from("file content");
+languageEncoding(content).then((fileInfo) => console.log(fileInfo));
 ```
 
 ### Via CLI

--- a/tests/node/node.test.js
+++ b/tests/node/node.test.js
@@ -50,6 +50,14 @@ testFiles.forEach((file) => {
     });
 });
 
+// Test buffer usage
+const buffer = Buffer.from("Content of a file");
+languageEncoding(buffer).then((bufferFileInfo) => {
+  if (bufferFileInfo.encoding !== "UTF-8") {
+    setError("buffer", bufferFileInfo);
+  }
+});
+
 // Recursively find all files in a folder and all it's subdirectories
 function getFiles(dir, files_) {
   files_ = files_ || [];


### PR DESCRIPTION
The workaround mentioned in `README.md` (https://github.com/gignupg/Detect-File-Encoding-And-Language/issues/3#issuecomment-1476074963) only works in the browser. This PR adds support für Buffer input in Node.js.