### PR TITLE
Remove BOM from `checkUTF.js` and `languageObject.js` files

### DIFF
--- a/src/components/checkUTF.js
+++ b/src/components/checkUTF.js
@@ -1,4 +1,4 @@
-﻿module.exports = (content) => {
+module.exports = (content) => {
     for (let b = 0; b < content.length; b++) {
         // If ? is encountered it's definitely not utf8!
         if (content[b] === "�") {

--- a/src/config/languageObject.js
+++ b/src/config/languageObject.js
@@ -1,4 +1,4 @@
-﻿const flag = "gi";
+const flag = "gi";
 
 const sharedRegex = {
     czech: new RegExp(/jsem|jsi/, flag),


### PR DESCRIPTION
Remove BOM (keep the UTF-8 encoding) from `src/components/checkUTF.js` file as this caused issues while making Vite 5 (Vite 4 was fine) build with heavy/production optimizations - browser error below, for some reason the error is about `checkUTFs` reference which seems to be caused by BOM of the file itself and Vite 5 build.

```text
example.vue:334  ReferenceError: checkUTFs is not defined
    at Bs (checkUTF.js:1:15)
    at Vs (index-browser.js:1:18)
    at index-browser.js:82:4
```

Tested with Vite 5.0.0 and in latest Edge and Chrome. Development builds which do not use heavy optimizations seems to work fine, so the root of the cause could be some Vite 5 production-level optimization.